### PR TITLE
Add missing dotenv dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "node-fetch": "^3.3.2",
     "socket.io": "^4.8.1",


### PR DESCRIPTION
## Summary
- include `dotenv` in project dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68529f589e248327b5443ad0a3c50140